### PR TITLE
added interface version check to use Genie4 #Browser to launch urls

### DIFF
--- a/Class1.cs
+++ b/Class1.cs
@@ -500,7 +500,7 @@ namespace InventoryView
 
         public string Version
         {
-            get { return "1.7"; }
+            get { return "1.8"; }
         }
 
         public string Description

--- a/InventoryViewForm.cs
+++ b/InventoryViewForm.cs
@@ -121,7 +121,17 @@ namespace InventoryView
             if (tv.SelectedNode == null)
                 MessageBox.Show("Select an item to lookup.");
             else
-                System.Diagnostics.Process.Start(string.Format("https://drservice.info/wiki.ashx?tap={0}", tv.SelectedNode.Text.Replace(" (closed)", "")));
+            {
+                Class1._host.EchoText(Class1._host.InterfaceVersion.ToString());
+                if(Class1._host.InterfaceVersion == 4)
+                {
+                    Class1._host.SendText(string.Format("#browser https://drservice.info/wiki.ashx?tap={0}", tv.SelectedNode.Text.Replace(" (closed)", "")));
+                }
+                else
+                {
+                    System.Diagnostics.Process.Start(string.Format("https://drservice.info/wiki.ashx?tap={0}", tv.SelectedNode.Text.Replace(" (closed)", "")));
+                }
+            }
         }
 
         private void btnReset_Click(object sender, EventArgs e)


### PR DESCRIPTION
System.Diagnostic.Process.Start is not supported in .NET 6. Genie now implements a .NET 6 platform agnostic method for launching browser links, which can be called by passing a URL with the command #BROWSER

I've added a version check which will use the new method if the interface is Genie 4, and the old if the interface is Genie 3, to be compatible with both versions.